### PR TITLE
Fix quickstart command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ docker compose up -d
 
 ```shell
 mkdir rpub && cd rpub
-bb -Sdeps '{:deps {dev.rpub/rpub {:mvn/version "0.1.0"}}}' -M -m rpub.tasks/supervisor --mvn/version 0.1.0
+bb -Sdeps '{:deps {dev.rpub/rpub {:mvn/version "0.1.0"}}}' -m rpub.tasks/supervisor --mvn/version 0.1.0
 ```
 
 ### Library


### PR DESCRIPTION
This looks like a nice project, congrats!

I was curious and wanted to the try the [quickstart command ](https://github.com/rpub-clj/rpub/edit/main/README.md#app-without-docker)

Unfortunately, it didn't work, I got:
```
...
Downloading: info/sunng/ring-jetty9-adapter/0.36.1/ring-jetty9-adapter-0.36.1.jar from clojars
Downloading: io/github/rads/inflections/0.14.2-1/inflections-0.14.2-1.jar from clojars
Downloading: org/babashka/json/0.1.6/json-0.1.6.jar from clojars
Downloading: babashka/fs/0.5.24/fs-0.5.24.jar from clojars
----- Error --------------------------------------------------------------------
Type:     java.lang.Exception
Message:  File does not exist: -M
```

So I tried
```
bb -Sdeps '{:deps {dev.rpub/rpub {:mvn/version "0.1.0"}}}' -m rpub.tasks/supervisor --mvn/version 0.1.0
```

And that seems to work! This change is in this PR.